### PR TITLE
Added option to bold the target word when creating a card

### DIFF
--- a/src/boxes/dict/script.js
+++ b/src/boxes/dict/script.js
@@ -27,7 +27,7 @@ window.addEventListener('DOMContentLoaded', () => {
     ankiIntegration, ankiDeckName, ankiModelName,
     ankiDictForm, ankiDictFormReading, ankiDictFormFurigana,
     ankiWord, ankiWordReading, ankiWordFurigana,
-    ankiDefinitions, ankiJapanese, ankiEnglish
+    ankiDefinitions, ankiJapanese, ankiEnglish, toogleBoldWord
   } = OPTIONS.get('options')
   if (darkMode) {
     document.documentElement.classList.add('dark-mode');
@@ -133,6 +133,10 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  const __anki__boldTargetWord = (fullText, word) => {
+    return fullText.replaceAll(word, `<b>${word}</b>`);
+  }
+
   async function __anki__addNote(wordData) {
     const fields = {};
     __anki__populateFieldsIfNonEmpty(fields, `${ankiDictForm}`, wordData.dictForm);
@@ -142,7 +146,10 @@ window.addEventListener('DOMContentLoaded', () => {
     __anki__populateFieldsIfNonEmpty(fields, `${ankiWordReading}`, wordData.rubyReading);
     __anki__populateFieldsIfNonEmpty(fields, `${ankiWordFurigana}`, wordData.wordFuriganaHTML);
     __anki__populateFieldsIfNonEmpty(fields, `${ankiDefinitions}`, wordData.definitions);
-    __anki__populateFieldsIfNonEmpty(fields, `${ankiJapanese}`, wordData.fullText);
+    __anki__populateFieldsIfNonEmpty(fields, `${ankiJapanese}`,
+    toogleBoldWord ? 
+    __anki__boldTargetWord(wordData.fullText, wordData.word)
+    : wordData.fullText);
     __anki__populateFieldsIfNonEmpty(fields, `${ankiEnglish}`, wordData.english);
     const res = await invoke('addNote', 6, {
       note: {

--- a/src/boxes/options/index.html
+++ b/src/boxes/options/index.html
@@ -193,7 +193,11 @@ The behavior is a bit 'smarter' if you leave this off.">
 The fields have to be unique. 
 The field can also be empty in which case it won't be inserted.">
               <input type="checkbox" id="ankiIntegration" name="ankiIntegration">
-              <label for="ankiIntegration">Anki integration (requires AnkiConnect)</label>
+              <label for="ankiIntegration">Anki integration (requires AnkiConnect)</label>         
+            </section>
+            <section id="ankiIntegration-boldTargetWord" class="option">
+              <input type="checkbox" id="toogleBoldWord" name="toogleBoldWord">
+              <label for="toogleBoldWord">Make the target word bold when creating the card.</label>
             </section>
             <section id="ankiDeckName-selection" class="option">
               <input type="text" spellcheck="false" id="ankiDeckName" name="ankiDeckName">

--- a/src/tools.js
+++ b/src/tools.js
@@ -26,6 +26,7 @@ const schemaOptions = {
             dictFontSize: { default: 12, type: "number", minimum: 1 },
             optionsFontSize: { default: 12, type: "number", minimum: 1 },
             ankiIntegration: { default: false, type: "boolean" },
+            toogleBoldWord: { default: false, type: "boolean" },
             ankiDeckName: { default: "japReader", type: "string" },
             ankiModelName: { default: "japReader", type: "string" },
             ankiDictForm: { default: "DictForm", type: "string" },


### PR DESCRIPTION
Most of the time when you add a sentence with the program it was hard to know which word you needed to review. 
Now, the word will always be set to bold when the card is created.

![image](https://github.com/marisukukise/japReader/assets/12613508/bdb5df5a-455b-4cbd-9d26-c2b1ba203a9d)

![image](https://github.com/marisukukise/japReader/assets/12613508/ce15e303-2cd9-4f9c-a762-f3f2f9660656)
